### PR TITLE
adding tests. simplifying getfbounds

### DIFF
--- a/tedana/selection/selection_nodes.py
+++ b/tedana/selection/selection_nodes.py
@@ -717,7 +717,8 @@ def calc_kappa_elbow(
     if "echo_dof" in selector.cross_component_metrics_.keys():
         echo_dof = selector.cross_component_metrics_["echo_dof"]
     else:
-        echo_dof = None
+        # DOF is number of echoes if not otherwise specified
+        echo_dof = selector.cross_component_metrics_["n_echos"]
     outputs = {
         "decision_node_idx": selector.current_node_idx_,
         "node_label": None,
@@ -782,8 +783,7 @@ def calc_kappa_elbow(
             outputs["varex_upper_p"],
         ) = kappa_elbow_kundu(
             selector.component_table_,
-            selector.cross_component_metrics_["n_echos"],
-            echo_dof=echo_dof,
+            echo_dof,
             comps2use=comps2use,
         )
         selector.cross_component_metrics_["kappa_elbow_kundu"] = outputs["kappa_elbow_kundu"]
@@ -855,7 +855,8 @@ def calc_rho_elbow(
     if "echo_dof" in selector.cross_component_metrics_.keys():
         echo_dof = selector.cross_component_metrics_["echo_dof"]
     else:
-        echo_dof = None
+        # DOF is number of echoes if not otherwise specified
+        echo_dof = selector.cross_component_metrics_["n_echos"]
 
     outputs = {
         "decision_node_idx": selector.current_node_idx_,
@@ -916,8 +917,7 @@ def calc_rho_elbow(
             outputs["elbow_f05"],
         ) = rho_elbow_kundu_liberal(
             selector.component_table_,
-            selector.cross_component_metrics_["n_echos"],
-            echo_dof=echo_dof,
+            echo_dof,
             rho_elbow_type=rho_elbow_type,
             comps2use=comps2use,
             subset_comps2use=subset_comps2use,

--- a/tedana/selection/selection_nodes.py
+++ b/tedana/selection/selection_nodes.py
@@ -714,7 +714,10 @@ def calc_kappa_elbow(
     This also means the kappa elbow should be calculated before those two other functions
     are called
     """
-    if "echo_dof" in selector.cross_component_metrics_.keys():
+    if (
+        "echo_dof" in selector.cross_component_metrics_.keys()
+        and selector.cross_component_metrics_["echo_dof"]
+    ):
         echo_dof = selector.cross_component_metrics_["echo_dof"]
     else:
         # DOF is number of echoes if not otherwise specified
@@ -852,7 +855,10 @@ def calc_rho_elbow(
             f"It is {rho_elbow_type} "
         )
 
-    if "echo_dof" in selector.cross_component_metrics_.keys():
+    if (
+        "echo_dof" in selector.cross_component_metrics_.keys()
+        and selector.cross_component_metrics_["echo_dof"]
+    ):
         echo_dof = selector.cross_component_metrics_["echo_dof"]
     else:
         # DOF is number of echoes if not otherwise specified

--- a/tedana/selection/selection_utils.py
+++ b/tedana/selection/selection_utils.py
@@ -580,7 +580,7 @@ def getelbow(arr, return_val=False):
         return k_min_ind
 
 
-def kappa_elbow_kundu(component_table, n_echos, echo_dof=None, comps2use=None):
+def kappa_elbow_kundu(component_table, echo_dof, comps2use=None):
     """
     Calculate an elbow for kappa.
 
@@ -592,12 +592,10 @@ def kappa_elbow_kundu(component_table, n_echos, echo_dof=None, comps2use=None):
         Component metric table. One row for each component, with a column for
         each metric. The index should be the component number.
         Only the 'kappa' column is used in this function
-    n_echos : :obj:`int`
-        The number of echos in the multi-echo data
-    echo_dof : :obj:`int`, optional
+    echo_dof : :obj:`int`
         Degree of freedom to use in goodness of fit metrics (fstat).
-        Primarily used for EPTI acquisitions.
-        If None, number of echoes will be used. Default is None.
+        Typically the number of echos in the multi-echo data
+        May be a lower value for EPTI acquisitions.
     comps2use : :obj:`list[int]`
         A list of component indices used to calculate the elbow
         default=None which means use all components
@@ -637,10 +635,7 @@ def kappa_elbow_kundu(component_table, n_echos, echo_dof=None, comps2use=None):
     kappas2use = component_table.loc[comps2use, "kappa"].to_numpy()
 
     # low kappa threshold
-    if echo_dof is None:
-        _, _, f01 = getfbounds(n_echos)
-    else:
-        _, _, f01 = getfbounds(echo_dof)
+    _, _, f01 = getfbounds(echo_dof)
     # get kappa values for components below a significance threshold
     kappas_nonsig = kappas2use[kappas2use < f01]
 
@@ -678,8 +673,7 @@ def kappa_elbow_kundu(component_table, n_echos, echo_dof=None, comps2use=None):
 
 def rho_elbow_kundu_liberal(
     component_table,
-    n_echos,
-    echo_dof=None,
+    echo_dof,
     rho_elbow_type="kundu",
     comps2use=None,
     subset_comps2use=-1,
@@ -696,12 +690,10 @@ def rho_elbow_kundu_liberal(
         Component metric table. One row for each component, with a column for
         each metric. The index should be the component number.
         Only the 'kappa' column is used in this function
-    n_echos : :obj:`int`
-        The number of echos in the multi-echo data
-    echo_dof : :obj:`int`, optional
+    echo_dof : :obj:`int`
         Degree of freedom to use in goodness of fit metrics (fstat).
-        Primarily used for EPTI acquisitions.
-        If None, number of echoes will be used. Default is None.
+        Typically the number of echos in the multi-echo data
+        May be a lower value for EPTI acquisitions.
     rho_elbow_type : :obj:`str`
         The algorithm used to calculate the rho elbow. Current options are
         'kundu' and 'liberal'.
@@ -769,10 +761,7 @@ def rho_elbow_kundu_liberal(
         ].tolist()
 
     # One rho elbow threshold set just on the number of echoes
-    if echo_dof is None:
-        elbow_f05, _, _ = getfbounds(n_echos)
-    else:
-        elbow_f05, _, _ = getfbounds(echo_dof)
+    elbow_f05, _, _ = getfbounds(echo_dof)
     # One rho elbow threshold set using all componets in comps2use
     rhos_comps2use = component_table.loc[comps2use, "rho"].to_numpy()
     rho_allcomps_elbow = getelbow(rhos_comps2use, return_val=True)

--- a/tedana/stats.py
+++ b/tedana/stats.py
@@ -11,14 +11,16 @@ LGR = logging.getLogger("GENERAL")
 RepLGR = logging.getLogger("REPORT")
 
 
-def getfbounds(n_echos):
+def getfbounds(echo_dof):
     """
     Get F-statistic boundaries based on number of echos.
 
     Parameters
     ----------
-    n_echos : :obj:`int`
-        Number of echoes
+    echo_dof : :obj:`int`
+        Degree of freedom to use in goodness of fit metrics (fstat).
+        Typically the number of echos in the multi-echo data
+        May be a lower value for EPTI acquisitions.
 
     Returns
     -------
@@ -26,9 +28,9 @@ def getfbounds(n_echos):
         F-statistic thresholds for alphas of 0.05, 0.025, and 0.01,
         respectively.
     """
-    f05 = stats.f.ppf(q=(1 - 0.05), dfn=1, dfd=(n_echos - 1))
-    f025 = stats.f.ppf(q=(1 - 0.025), dfn=1, dfd=(n_echos - 1))
-    f01 = stats.f.ppf(q=(1 - 0.01), dfn=1, dfd=(n_echos - 1))
+    f05 = stats.f.ppf(q=(1 - 0.05), dfn=1, dfd=(echo_dof - 1))
+    f025 = stats.f.ppf(q=(1 - 0.025), dfn=1, dfd=(echo_dof - 1))
+    f01 = stats.f.ppf(q=(1 - 0.01), dfn=1, dfd=(echo_dof - 1))
     return f05, f025, f01
 
 

--- a/tedana/tests/test_integration.py
+++ b/tedana/tests/test_integration.py
@@ -126,11 +126,13 @@ def test_integration_five_echo(skip_integration):
     suffix = ".sm.nii.gz"
     datalist = [prepend + str(i + 1) + suffix for i in range(5)]
     echo_times = [15.4, 29.7, 44.0, 58.3, 72.6]
+    # also adding echo_dof=4 to make sure all workflow code using echo_dof is executed
     tedana_cli.tedana_workflow(
         data=datalist,
         tes=echo_times,
         ica_method="robustica",
         n_robust_runs=4,
+        echo_dof=4,
         out_dir=out_dir,
         tedpca=0.95,
         fittype="curvefit",
@@ -631,6 +633,7 @@ def test_integration_t2smap(skip_integration):
         + [str(te) for te in echo_times]
         + ["--out-dir", out_dir, "--fittype", "curvefit"]
         + ["--masktype", "dropout", "decay"]
+        + ["--n-independent-echos", "4"]
     )
     t2smap_cli._main(args)
 

--- a/tedana/tests/test_metrics.py
+++ b/tedana/tests/test_metrics.py
@@ -228,10 +228,10 @@ def test_smoke_calculate_f_maps():
         f_max=500,
     )
     assert f_t2_maps.shape == f_s0_maps.shape == (n_voxels, n_components)
-    # When echo_dof < the number of echoes, then the f maps should have the same or larger values
+    # When echo_dof < the number of echoes, then f_maps_orig should have the same or larger values
     assert np.min(f_t2_maps_orig - f_t2_maps) == 0
     assert np.min(f_s0_maps_orig - f_s0_maps) == 0
-    # When echo_dof==3 and there are 5 good echoes, then the f maps should always be larger than 0
+    # When echo_dof==3 and there are 5 good echoes, then f_maps_orig should always be larger than 0
     assert np.min(f_t2_maps_orig[adaptive_mask == 5] - f_t2_maps[adaptive_mask == 5]) > 0
     assert np.min(f_s0_maps_orig[adaptive_mask == 5] - f_s0_maps[adaptive_mask == 5]) > 0
 

--- a/tedana/tests/test_selection_utils.py
+++ b/tedana/tests/test_selection_utils.py
@@ -388,7 +388,7 @@ def test_kappa_elbow_kundu_smoke():
         kappa_allcomps_elbow,
         kappa_nonsig_elbow,
         varex_upper_p,
-    ) = selection_utils.kappa_elbow_kundu(component_table, n_echos=5)
+    ) = selection_utils.kappa_elbow_kundu(component_table, echo_dof=5)
     assert isinstance(kappa_elbow_kundu, float)
     assert isinstance(kappa_allcomps_elbow, float)
     assert isinstance(kappa_nonsig_elbow, float)
@@ -401,7 +401,7 @@ def test_kappa_elbow_kundu_smoke():
         kappa_allcomps_elbow,
         kappa_nonsig_elbow,
         varex_upper_p,
-    ) = selection_utils.kappa_elbow_kundu(component_table, n_echos=6)
+    ) = selection_utils.kappa_elbow_kundu(component_table, echo_dof=6)
     assert isinstance(kappa_elbow_kundu, float)
     assert isinstance(kappa_allcomps_elbow, float)
     assert isinstance(kappa_nonsig_elbow, type(None))
@@ -415,7 +415,7 @@ def test_kappa_elbow_kundu_smoke():
         varex_upper_p,
     ) = selection_utils.kappa_elbow_kundu(
         component_table,
-        n_echos=5,
+        echo_dof=5,
         comps2use=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 14, 15, 17, 18, 20],
     )
     assert isinstance(kappa_elbow_kundu, float)
@@ -434,7 +434,7 @@ def test_rho_elbow_kundu_liberal_smoke():
         rho_allcomps_elbow,
         rho_unclassified_elbow,
         elbow_f05,
-    ) = selection_utils.rho_elbow_kundu_liberal(component_table, n_echos=3)
+    ) = selection_utils.rho_elbow_kundu_liberal(component_table, echo_dof=3)
     assert isinstance(rho_elbow_kundu, float)
     assert isinstance(rho_allcomps_elbow, float)
     assert isinstance(rho_unclassified_elbow, float)
@@ -447,7 +447,7 @@ def test_rho_elbow_kundu_liberal_smoke():
         rho_unclassified_elbow,
         elbow_f05,
     ) = selection_utils.rho_elbow_kundu_liberal(
-        component_table, n_echos=3, rho_elbow_type="liberal"
+        component_table, echo_dof=3, rho_elbow_type="liberal"
     )
     assert isinstance(rho_elbow_kundu, float)
     assert isinstance(rho_allcomps_elbow, float)
@@ -462,7 +462,7 @@ def test_rho_elbow_kundu_liberal_smoke():
         elbow_f05,
     ) = selection_utils.rho_elbow_kundu_liberal(
         component_table,
-        n_echos=3,
+        echo_dof=3,
         rho_elbow_type="kundu",
         comps2use=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 14, 15, 17, 18, 20],
         subset_comps2use=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 14, 18, 20],
@@ -479,7 +479,7 @@ def test_rho_elbow_kundu_liberal_smoke():
         rho_allcomps_elbow,
         rho_unclassified_elbow,
         elbow_f05,
-    ) = selection_utils.rho_elbow_kundu_liberal(component_table, n_echos=3)
+    ) = selection_utils.rho_elbow_kundu_liberal(component_table, echo_dof=3)
     assert isinstance(rho_elbow_kundu, float)
     assert isinstance(rho_allcomps_elbow, float)
     assert isinstance(rho_unclassified_elbow, type(None))
@@ -487,7 +487,7 @@ def test_rho_elbow_kundu_liberal_smoke():
 
     with pytest.raises(ValueError):
         selection_utils.rho_elbow_kundu_liberal(
-            component_table, n_echos=3, rho_elbow_type="perfect"
+            component_table, echo_dof=3, rho_elbow_type="perfect"
         )
 
 

--- a/tedana/utils.py
+++ b/tedana/utils.py
@@ -240,14 +240,15 @@ def make_adaptive_mask(data, mask, echo_dof=None, threshold=1, methods=["dropout
         # To track this, we are flagging voxels that might mark less independant signal.
         # If such voxels appear often, this would show we might need to alter how the mask is used.
         # The thresh where there might not be 3 independent sources of data within the good echoes
-        # For n_echos=100 & echo_dof=3, threshold_dof=66.6.
+        # For n_echos=100 & echo_dof=3, threshold_dof=66.
         # For n_echos=100 & echo_dof=4, threshold_dof=50
-        threshold_3dof = 2 * n_echos / echo_dof
+        threshold_3dof = np.floor(2 * n_echos / echo_dof)
         n_3dof_voxels = np.sum(np.logical_and(adaptive_mask < threshold_3dof, adaptive_mask >= 1))
         perc_3dof_voxels = 100 * n_3dof_voxels / np.sum(adaptive_mask >= 1)
         if perc_3dof_voxels > 0:
             LGR.warning(
-                f"{n_3dof_voxels} voxels ({perc_3dof_voxels}%) have fewer than {threshold_3dof} "
+                f"{n_3dof_voxels} voxels ({np.round(perc_3dof_voxels, decimals=1)}%) have fewer "
+                f"than {np.round(threshold_3dof)} "
                 "good voxels. These voxels will be used in all analyses, "
                 "but might not include 3 independant echo measurements."
             )
@@ -255,14 +256,14 @@ def make_adaptive_mask(data, mask, echo_dof=None, threshold=1, methods=["dropout
         if echo_dof > 3:
             # The threshold where the loss of good echoes might affect the DOF
             # For n_echos=100 & echo_dof=4, threshold_dof=75
-            threshold_dof = (echo_dof - 1) * n_echos / echo_dof
+            threshold_dof = np.floor((echo_dof - 1) * n_echos / echo_dof)
             n_dof_voxels = np.sum(
                 np.logical_and(adaptive_mask < threshold_dof, adaptive_mask >= 1)
             )
             perc_dof_voxels = 100 * n_dof_voxels / np.sum(adaptive_mask >= 1)
             LGR.warning(
-                f"{n_dof_voxels} voxels ({perc_dof_voxels}%) have fewer than {threshold_dof} "
-                "good voxels."
+                f"{n_dof_voxels} voxels ({np.round(perc_dof_voxels, decimals=1)}%) have fewer "
+                f"than {np.round(threshold_dof)} good voxels. "
                 f"The degrees of freedom for fits across echoes will remain {echo_dof} even if "
                 "there might be fewer independant echo measurements."
             )

--- a/tedana/workflows/t2smap.py
+++ b/tedana/workflows/t2smap.py
@@ -133,6 +133,18 @@ def _get_parser():
         default="t2s",
     )
     optional.add_argument(
+        "--n-independent-echos",
+        dest="echo_dof",
+        metavar="INT",
+        type=int,
+        help=(
+            "Degree of freedom to use in goodness of fit metrics (fstat)."
+            "Primarily used for EPTI acquisitions."
+            "If not provided, number of echoes will be used."
+        ),
+        default=None,
+    )
+    optional.add_argument(
         "--n-threads",
         dest="n_threads",
         type=int,
@@ -231,7 +243,6 @@ def t2smap_workflow(
         Generate intermediate and additional files. Default is False.
     overwrite : :obj:`bool`, optional
         If True, force overwriting of files. Default is False.
-
 
     Other Parameters
     ----------------


### PR DESCRIPTION
@katielamar I'm still working on this, so don't merge yet, but I figured I'd share.

Once nice thing about writing tests is that I notice other issues. In trying to create the test, I realized that `getfbounds` and a few functions that just called that were being passed `n_echos` and `echo_dof`, & using only one for the exact same thing. Writing a test for how to handle `n_echos` vs `echo_dof` didn't make any sense. Since this is a statistical function and the parameter for the statistic is the DOF,  i decided to replace `n_echoes` with `echo_dof` in all those functions. In the functions that call it, `echo_dof=n_echoes` when `echo_dof==None`.

I still have at least one more test to add so I'm setting this as a draft PR.