### PR TITLE
Changed echo_dof to n_independent_echos

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -125,7 +125,7 @@ The clear failure cases are extreme. That is getting less than 1/5 the number of
 compared to time points or having nearly as many components as time points.
 We are working on identifying why this happens and adding better solutions.
 Our current guess is that most of the above methods assume data are
-independant and identically distributed (IID),
+independent and identically distributed (IID),
 and signal leakage from in-slice and multi-slice accelleration may violate this assumption.
 
 We have one option that is generally useful and is also a partial solution.

--- a/tedana/decomposition/pca.py
+++ b/tedana/decomposition/pca.py
@@ -55,7 +55,7 @@ def tedpca(
     adaptive_mask,
     io_generator,
     tes,
-    echo_dof=None,
+    n_independent_echos=None,
     algorithm="aic",
     kdaw=10.0,
     rdaw=1.0,
@@ -80,8 +80,8 @@ def tedpca(
         The output generation object for this workflow
     tes : :obj:`list`
         List of echo times associated with `data_cat`, in milliseconds
-    echo_dof : :obj:`int`, optional
-        Degree of freedom to use in goodness of fit metrics (fstat).
+    n_independent_echos : :obj:`int`, optional
+        Number of independent echoes to use in goodness of fit metrics (fstat).
         Primarily used for EPTI acquisitions.
         If None, number of echoes will be used. Default is None.
     algorithm : {'kundu', 'kundu-stabilize', 'mdl', 'aic', 'kic', float}, optional
@@ -360,7 +360,7 @@ def tedpca(
         mixing=comp_ts,
         adaptive_mask=adaptive_mask,
         tes=tes,
-        echo_dof=echo_dof,
+        n_independent_echos=n_independent_echos,
         io_generator=io_generator,
         label="PCA",
         external_regressors=None,
@@ -383,7 +383,7 @@ def tedpca(
         component_table, metric_metadata = kundu_tedpca(
             component_table,
             n_echos,
-            echo_dof,
+            n_independent_echos,
             kdaw,
             rdaw,
             stabilize=False,
@@ -392,7 +392,7 @@ def tedpca(
         component_table, metric_metadata = kundu_tedpca(
             component_table,
             n_echos,
-            echo_dof,
+            n_independent_echos,
             kdaw,
             rdaw,
             stabilize=True,

--- a/tedana/metrics/collect.py
+++ b/tedana/metrics/collect.py
@@ -29,7 +29,7 @@ def generate_metrics(
     mixing: npt.NDArray,
     adaptive_mask: npt.NDArray,
     tes: Union[List[int], List[float], npt.NDArray],
-    echo_dof: int = None,
+    n_independent_echos: int = None,
     io_generator: io.OutputGenerator,
     label: str,
     external_regressors: Union[pd.DataFrame, None] = None,
@@ -54,8 +54,8 @@ def generate_metrics(
         For more information on thresholding, see `make_adaptive_mask`.
     tes : list
         List of echo times associated with `data_cat`, in milliseconds
-    echo_dof : int
-        Degree of freedom to use in goodness of fit metrics (fstat).
+    n_independent_echos : int
+        Number of independent echoes to use in goodness of fit metrics (fstat).
         Primarily used for EPTI acquisitions.
         If None, number of echoes will be used. Default is None.
     io_generator : tedana.io.OutputGenerator
@@ -201,7 +201,7 @@ def generate_metrics(
             mixing=mixing,
             adaptive_mask=adaptive_mask,
             tes=tes,
-            echo_dof=echo_dof,
+            n_independent_echos=n_independent_echos,
         )
         metric_maps["map FT2"] = m_t2
         metric_maps["map FS0"] = m_s0
@@ -230,10 +230,9 @@ def generate_metrics(
 
     if "map FT2 clusterized" in required_metrics:
         LGR.info("Calculating T2* F-statistic maps")
-        if echo_dof is None:
-            f_thresh, _, _ = getfbounds(len(tes))
-        else:
-            f_thresh, _, _ = getfbounds(echo_dof)
+        # use either the inputted number of indie echoes or the total number of echoes
+        n_independent_echos = n_independent_echos or len(tes)
+        f_thresh, _, _ = getfbounds(n_independent_echos)
 
         metric_maps["map FT2 clusterized"] = dependence.threshold_map(
             maps=metric_maps["map FT2"],
@@ -244,10 +243,9 @@ def generate_metrics(
 
     if "map FS0 clusterized" in required_metrics:
         LGR.info("Calculating S0 F-statistic maps")
-        if echo_dof is None:
-            f_thresh, _, _ = getfbounds(len(tes))
-        else:
-            f_thresh, _, _ = getfbounds(echo_dof)
+        # use either the inputted number of indie echoes or the total number of echoes
+        n_independent_echos = n_independent_echos or len(tes)
+        f_thresh, _, _ = getfbounds(n_independent_echos)
 
         metric_maps["map FS0 clusterized"] = dependence.threshold_map(
             maps=metric_maps["map FS0"],

--- a/tedana/metrics/dependence.py
+++ b/tedana/metrics/dependence.py
@@ -136,7 +136,7 @@ def calculate_f_maps(
     mixing: np.ndarray,
     adaptive_mask: np.ndarray,
     tes: np.ndarray,
-    echo_dof=None,
+    n_independent_echos=None,
     f_max: float = 500,
 ) -> typing.Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """Calculate pseudo-F-statistic maps for TE-dependence and -independence models.
@@ -154,8 +154,8 @@ def calculate_f_maps(
         "good signal". Limited to masked voxels.
     tes : (E) array_like
         Echo times in milliseconds, in the same order as the echoes in data_cat.
-    echo_dof : int
-        Degree of freedom to use in goodness of fit metrics (fstat).
+    n_independent_echos : int
+        Number of independent echoes to use in goodness of fit metrics (fstat).
         Primarily used for EPTI acquisitions.
         If None, number of echoes will be used. Default is None.
     f_max : float, optional
@@ -206,10 +206,10 @@ def calculate_f_maps(
             pred_s0 = x1[:j_echo, :] * np.tile(coeffs_s0, (j_echo, 1))
             sse_s0 = (comp_betas[:j_echo] - pred_s0) ** 2
             sse_s0 = sse_s0.sum(axis=0)  # (S,) prediction error map
-            if echo_dof is None:
+            if n_independent_echos is None or n_independent_echos >= j_echo:
                 f_s0 = (alpha - sse_s0) * (j_echo - 1) / (sse_s0)
             else:
-                f_s0 = (alpha - sse_s0) * (echo_dof - 1) / (sse_s0)
+                f_s0 = (alpha - sse_s0) * (n_independent_echos - 1) / (sse_s0)
             f_s0[f_s0 > f_max] = f_max
             f_s0_maps[mask_idx, i_comp] = f_s0[mask_idx]
 
@@ -220,10 +220,10 @@ def calculate_f_maps(
             pred_t2 = x2[:j_echo] * np.tile(coeffs_t2, (j_echo, 1))
             sse_t2 = (comp_betas[:j_echo] - pred_t2) ** 2
             sse_t2 = sse_t2.sum(axis=0)
-            if echo_dof is None:
+            if n_independent_echos is None or n_independent_echos >= j_echo:
                 f_t2 = (alpha - sse_t2) * (j_echo - 1) / (sse_t2)
             else:
-                f_t2 = (alpha - sse_t2) * (echo_dof - 1) / (sse_t2)
+                f_t2 = (alpha - sse_t2) * (n_independent_echos - 1) / (sse_t2)
             f_t2[f_t2 > f_max] = f_max
             f_t2_maps[mask_idx, i_comp] = f_t2[mask_idx]
 

--- a/tedana/selection/selection_nodes.py
+++ b/tedana/selection/selection_nodes.py
@@ -715,18 +715,18 @@ def calc_kappa_elbow(
     are called
     """
     if (
-        "echo_dof" in selector.cross_component_metrics_.keys()
-        and selector.cross_component_metrics_["echo_dof"]
+        "n_independent_echos" in selector.cross_component_metrics_.keys()
+        and selector.cross_component_metrics_["n_independent_echos"]
     ):
-        echo_dof = selector.cross_component_metrics_["echo_dof"]
+        n_independent_echos = selector.cross_component_metrics_["n_independent_echos"]
     else:
-        # DOF is number of echoes if not otherwise specified
-        echo_dof = selector.cross_component_metrics_["n_echos"]
+        # Number of independent echoes is the number of echoes if not otherwise specified
+        n_independent_echos = selector.cross_component_metrics_["n_echos"]
     outputs = {
         "decision_node_idx": selector.current_node_idx_,
         "node_label": None,
         "n_echos": selector.cross_component_metrics_["n_echos"],
-        "echo_dof": echo_dof,
+        "n_independent_echos": n_independent_echos,
         "used_metrics": {"kappa"},
         "calc_cross_comp_metrics": [
             "kappa_elbow_kundu",
@@ -786,7 +786,7 @@ def calc_kappa_elbow(
             outputs["varex_upper_p"],
         ) = kappa_elbow_kundu(
             selector.component_table_,
-            echo_dof,
+            n_independent_echos,
             comps2use=comps2use,
         )
         selector.cross_component_metrics_["kappa_elbow_kundu"] = outputs["kappa_elbow_kundu"]
@@ -856,19 +856,19 @@ def calc_rho_elbow(
         )
 
     if (
-        "echo_dof" in selector.cross_component_metrics_.keys()
-        and selector.cross_component_metrics_["echo_dof"]
+        "n_independent_echos" in selector.cross_component_metrics_.keys()
+        and selector.cross_component_metrics_["n_independent_echos"]
     ):
-        echo_dof = selector.cross_component_metrics_["echo_dof"]
+        n_independent_echos = selector.cross_component_metrics_["n_independent_echos"]
     else:
         # DOF is number of echoes if not otherwise specified
-        echo_dof = selector.cross_component_metrics_["n_echos"]
+        n_independent_echos = selector.cross_component_metrics_["n_echos"]
 
     outputs = {
         "decision_node_idx": selector.current_node_idx_,
         "node_label": None,
         "n_echos": selector.cross_component_metrics_["n_echos"],
-        "echo_dof": echo_dof,
+        "n_independent_echos": n_independent_echos,
         "calc_cross_comp_metrics": [
             elbow_name,
             "rho_allcomps_elbow",
@@ -923,7 +923,7 @@ def calc_rho_elbow(
             outputs["elbow_f05"],
         ) = rho_elbow_kundu_liberal(
             selector.component_table_,
-            echo_dof,
+            n_independent_echos,
             rho_elbow_type=rho_elbow_type,
             comps2use=comps2use,
             subset_comps2use=subset_comps2use,

--- a/tedana/selection/selection_utils.py
+++ b/tedana/selection/selection_utils.py
@@ -580,7 +580,7 @@ def getelbow(arr, return_val=False):
         return k_min_ind
 
 
-def kappa_elbow_kundu(component_table, echo_dof, comps2use=None):
+def kappa_elbow_kundu(component_table, n_independent_echos, comps2use=None):
     """
     Calculate an elbow for kappa.
 
@@ -592,8 +592,8 @@ def kappa_elbow_kundu(component_table, echo_dof, comps2use=None):
         Component metric table. One row for each component, with a column for
         each metric. The index should be the component number.
         Only the 'kappa' column is used in this function
-    echo_dof : :obj:`int`
-        Degree of freedom to use in goodness of fit metrics (fstat).
+    n_independent_echos : :obj:`int`
+        Number of independent echoes to use in goodness of fit metrics (fstat).
         Typically the number of echos in the multi-echo data
         May be a lower value for EPTI acquisitions.
     comps2use : :obj:`list[int]`
@@ -635,7 +635,7 @@ def kappa_elbow_kundu(component_table, echo_dof, comps2use=None):
     kappas2use = component_table.loc[comps2use, "kappa"].to_numpy()
 
     # low kappa threshold
-    _, _, f01 = getfbounds(echo_dof)
+    _, _, f01 = getfbounds(n_independent_echos)
     # get kappa values for components below a significance threshold
     kappas_nonsig = kappas2use[kappas2use < f01]
 
@@ -673,7 +673,7 @@ def kappa_elbow_kundu(component_table, echo_dof, comps2use=None):
 
 def rho_elbow_kundu_liberal(
     component_table,
-    echo_dof,
+    n_independent_echos,
     rho_elbow_type="kundu",
     comps2use=None,
     subset_comps2use=-1,
@@ -690,8 +690,8 @@ def rho_elbow_kundu_liberal(
         Component metric table. One row for each component, with a column for
         each metric. The index should be the component number.
         Only the 'kappa' column is used in this function
-    echo_dof : :obj:`int`
-        Degree of freedom to use in goodness of fit metrics (fstat).
+    n_independent_echos : :obj:`int`
+        Number of independent echoes to use in goodness of fit metrics (fstat).
         Typically the number of echos in the multi-echo data
         May be a lower value for EPTI acquisitions.
     rho_elbow_type : :obj:`str`
@@ -761,7 +761,7 @@ def rho_elbow_kundu_liberal(
         ].tolist()
 
     # One rho elbow threshold set just on the number of echoes
-    elbow_f05, _, _ = getfbounds(echo_dof)
+    elbow_f05, _, _ = getfbounds(n_independent_echos)
     # One rho elbow threshold set using all componets in comps2use
     rhos_comps2use = component_table.loc[comps2use, "rho"].to_numpy()
     rho_allcomps_elbow = getelbow(rhos_comps2use, return_val=True)

--- a/tedana/selection/tedpca.py
+++ b/tedana/selection/tedpca.py
@@ -15,7 +15,9 @@ RepLGR = logging.getLogger("REPORT")
 F_MAX = 500
 
 
-def kundu_tedpca(component_table, n_echos, echo_dof=None, kdaw=10.0, rdaw=1.0, stabilize=False):
+def kundu_tedpca(
+    component_table, n_echos, n_independent_echos=None, kdaw=10.0, rdaw=1.0, stabilize=False
+):
     """Select PCA components using Kundu's decision tree approach.
 
     Parameters
@@ -25,8 +27,8 @@ def kundu_tedpca(component_table, n_echos, echo_dof=None, kdaw=10.0, rdaw=1.0, s
         variance explained. Component number should be the index.
     n_echos : :obj:`int`
         Number of echoes in dataset.
-    echo_dof : int
-        Degree of freedom to use in goodness of fit metrics (fstat).
+    n_independent_echos : int
+        Number of independent echoes to use in goodness of fit metrics (fstat).
         Primarily used for EPTI acquisitions.
         If None, number of echoes will be used. Default is None.
     kdaw : :obj:`float`, optional
@@ -63,10 +65,8 @@ def kundu_tedpca(component_table, n_echos, echo_dof=None, kdaw=10.0, rdaw=1.0, s
         + 1
     ]
     varex_norm_cum = np.cumsum(component_table["normalized variance explained"])
-    if echo_dof is None:
-        fmin, fmid, fmax = getfbounds(n_echos)
-    else:
-        fmin, fmid, fmax = getfbounds(echo_dof)
+    n_independent_echos = n_independent_echos or n_echos
+    fmin, fmid, fmax = getfbounds(n_independent_echos)
 
     if int(kdaw) == -1:
         lim_idx = (

--- a/tedana/stats.py
+++ b/tedana/stats.py
@@ -11,14 +11,14 @@ LGR = logging.getLogger("GENERAL")
 RepLGR = logging.getLogger("REPORT")
 
 
-def getfbounds(echo_dof):
+def getfbounds(n_independent_sources):
     """
     Get F-statistic boundaries based on number of echos.
 
     Parameters
     ----------
-    echo_dof : :obj:`int`
-        Degree of freedom to use in goodness of fit metrics (fstat).
+    n_independent_sources : :obj:`int`
+        The number of independent sources to calculate DOF for goodness of fit metrics (fstat).
         Typically the number of echos in the multi-echo data
         May be a lower value for EPTI acquisitions.
 
@@ -28,9 +28,9 @@ def getfbounds(echo_dof):
         F-statistic thresholds for alphas of 0.05, 0.025, and 0.01,
         respectively.
     """
-    f05 = stats.f.ppf(q=(1 - 0.05), dfn=1, dfd=(echo_dof - 1))
-    f025 = stats.f.ppf(q=(1 - 0.025), dfn=1, dfd=(echo_dof - 1))
-    f01 = stats.f.ppf(q=(1 - 0.01), dfn=1, dfd=(echo_dof - 1))
+    f05 = stats.f.ppf(q=(1 - 0.05), dfn=1, dfd=(n_independent_sources - 1))
+    f025 = stats.f.ppf(q=(1 - 0.025), dfn=1, dfd=(n_independent_sources - 1))
+    f01 = stats.f.ppf(q=(1 - 0.01), dfn=1, dfd=(n_independent_sources - 1))
     return f05, f025, f01
 
 

--- a/tedana/tests/test_integration.py
+++ b/tedana/tests/test_integration.py
@@ -126,13 +126,13 @@ def test_integration_five_echo(skip_integration):
     suffix = ".sm.nii.gz"
     datalist = [prepend + str(i + 1) + suffix for i in range(5)]
     echo_times = [15.4, 29.7, 44.0, 58.3, 72.6]
-    # also adding echo_dof=4 to make sure all workflow code using echo_dof is executed
+    # adding n_independent_echos=4 to test workflow code using n_independent_echos is executed
     tedana_cli.tedana_workflow(
         data=datalist,
         tes=echo_times,
         ica_method="robustica",
         n_robust_runs=4,
-        echo_dof=4,
+        n_independent_echos=4,
         out_dir=out_dir,
         tedpca=0.95,
         fittype="curvefit",

--- a/tedana/tests/test_metrics.py
+++ b/tedana/tests/test_metrics.py
@@ -205,7 +205,18 @@ def test_smoke_calculate_f_maps():
     data_cat = np.random.random((n_voxels, n_echos, n_volumes))
     z_maps = np.random.normal(size=(n_voxels, n_components))
     mixing = np.random.random((n_volumes, n_components))
-    adaptive_mask = np.random.randint(1, n_echos + 1, size=n_voxels)
+    # The ordering is random, but make sure the adaptive mask always includes values of 1-5
+    adaptive_mask = np.random.permutation(
+        np.concat(
+            (
+                np.tile(1, int(np.round(n_voxels * 0.05))),
+                np.tile(2, int(np.round(n_voxels * 0.1))),
+                np.tile(3, int(np.round(n_voxels * 0.4))),
+                np.tile(4, int(np.round(n_voxels * 0.2))),
+                np.tile(5, int(np.round(n_voxels * 0.25))),
+            )
+        )
+    )
     tes = np.array([15, 25, 35, 45, 55])
     f_t2_maps_orig, f_s0_maps_orig, _, _ = dependence.calculate_f_maps(
         data_cat=data_cat,
@@ -217,23 +228,42 @@ def test_smoke_calculate_f_maps():
     )
     assert f_t2_maps_orig.shape == f_s0_maps_orig.shape == (n_voxels, n_components)
 
-    # rerunning with echo_dof=3
+    # rerunning with n_independent_echos=3
     f_t2_maps, f_s0_maps, _, _ = dependence.calculate_f_maps(
         data_cat=data_cat,
         z_maps=z_maps,
         mixing=mixing,
         adaptive_mask=adaptive_mask,
         tes=tes,
-        echo_dof=3,
+        n_independent_echos=3,
         f_max=500,
     )
     assert f_t2_maps.shape == f_s0_maps.shape == (n_voxels, n_components)
-    # When echo_dof < the number of echoes, then f_maps_orig should have the same or larger values
-    assert np.round(np.min(f_t2_maps_orig - f_t2_maps), decimals=3) == np.round(0.0, decimals=3)
-    assert np.round(np.min(f_s0_maps_orig - f_s0_maps), decimals=3) == np.round(0.0, decimals=3)
-    # When echo_dof==3, there are 5 good echoes, and f_maps_orig>0
+    # exclude voxels f==0 and f==f_max since the >0 clause for 5 echoes wouldn't be true
+    noextreme_f_mask = np.logical_and(
+        np.logical_and(
+            np.logical_and(f_t2_maps_orig > 0.0, f_s0_maps_orig > 0.0), f_t2_maps_orig < 500
+        ),
+        f_s0_maps_orig < 500,
+    )
+    # When n_independent_echos == the number of echoes (3),
+    # then f_maps_orig should equal f_maps
+    echo3_mask = np.logical_and(np.tile(adaptive_mask == 3, (50, 1)).T, noextreme_f_mask)
+    assert np.round(
+        np.min(f_t2_maps_orig[echo3_mask] - f_t2_maps[echo3_mask]), decimals=3
+    ) == np.round(0.0, decimals=3)
+    assert np.round(
+        np.min(f_s0_maps_orig[echo3_mask] - f_s0_maps[echo3_mask]), decimals=3
+    ) == np.round(0.0, decimals=3)
+    assert np.round(
+        np.max(f_t2_maps_orig[echo3_mask] - f_t2_maps[echo3_mask]), decimals=3
+    ) == np.round(0.0, decimals=3)
+    assert np.round(
+        np.max(f_s0_maps_orig[echo3_mask] - f_s0_maps[echo3_mask]), decimals=3
+    ) == np.round(0.0, decimals=3)
+    # When n_independent_echos==3, there are 5 good echoes,
     # then f_maps_orig should always be larger than f_maps with fewer DOF
-    echo5_mask = np.logical_and(np.tile(adaptive_mask == 5, (50, 1)).T, f_t2_maps_orig > 0.0)
+    echo5_mask = np.logical_and(np.tile(adaptive_mask == 5, (50, 1)).T, noextreme_f_mask)
     assert np.min(f_t2_maps_orig[echo5_mask] - f_t2_maps[echo5_mask]) > 0.0
     assert np.min(f_s0_maps_orig[echo5_mask] - f_s0_maps[echo5_mask]) > 0.0
 

--- a/tedana/tests/test_selection_utils.py
+++ b/tedana/tests/test_selection_utils.py
@@ -388,7 +388,7 @@ def test_kappa_elbow_kundu_smoke():
         kappa_allcomps_elbow,
         kappa_nonsig_elbow,
         varex_upper_p,
-    ) = selection_utils.kappa_elbow_kundu(component_table, echo_dof=5)
+    ) = selection_utils.kappa_elbow_kundu(component_table, n_independent_echos=5)
     assert isinstance(kappa_elbow_kundu, float)
     assert isinstance(kappa_allcomps_elbow, float)
     assert isinstance(kappa_nonsig_elbow, float)
@@ -401,7 +401,7 @@ def test_kappa_elbow_kundu_smoke():
         kappa_allcomps_elbow,
         kappa_nonsig_elbow,
         varex_upper_p,
-    ) = selection_utils.kappa_elbow_kundu(component_table, echo_dof=6)
+    ) = selection_utils.kappa_elbow_kundu(component_table, n_independent_echos=6)
     assert isinstance(kappa_elbow_kundu, float)
     assert isinstance(kappa_allcomps_elbow, float)
     assert isinstance(kappa_nonsig_elbow, type(None))
@@ -415,7 +415,7 @@ def test_kappa_elbow_kundu_smoke():
         varex_upper_p,
     ) = selection_utils.kappa_elbow_kundu(
         component_table,
-        echo_dof=5,
+        n_independent_echos=5,
         comps2use=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 14, 15, 17, 18, 20],
     )
     assert isinstance(kappa_elbow_kundu, float)
@@ -434,7 +434,7 @@ def test_rho_elbow_kundu_liberal_smoke():
         rho_allcomps_elbow,
         rho_unclassified_elbow,
         elbow_f05,
-    ) = selection_utils.rho_elbow_kundu_liberal(component_table, echo_dof=3)
+    ) = selection_utils.rho_elbow_kundu_liberal(component_table, n_independent_echos=3)
     assert isinstance(rho_elbow_kundu, float)
     assert isinstance(rho_allcomps_elbow, float)
     assert isinstance(rho_unclassified_elbow, float)
@@ -447,7 +447,7 @@ def test_rho_elbow_kundu_liberal_smoke():
         rho_unclassified_elbow,
         elbow_f05,
     ) = selection_utils.rho_elbow_kundu_liberal(
-        component_table, echo_dof=3, rho_elbow_type="liberal"
+        component_table, n_independent_echos=3, rho_elbow_type="liberal"
     )
     assert isinstance(rho_elbow_kundu, float)
     assert isinstance(rho_allcomps_elbow, float)
@@ -462,7 +462,7 @@ def test_rho_elbow_kundu_liberal_smoke():
         elbow_f05,
     ) = selection_utils.rho_elbow_kundu_liberal(
         component_table,
-        echo_dof=3,
+        n_independent_echos=3,
         rho_elbow_type="kundu",
         comps2use=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 14, 15, 17, 18, 20],
         subset_comps2use=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 14, 18, 20],
@@ -479,7 +479,7 @@ def test_rho_elbow_kundu_liberal_smoke():
         rho_allcomps_elbow,
         rho_unclassified_elbow,
         elbow_f05,
-    ) = selection_utils.rho_elbow_kundu_liberal(component_table, echo_dof=3)
+    ) = selection_utils.rho_elbow_kundu_liberal(component_table, n_independent_echos=3)
     assert isinstance(rho_elbow_kundu, float)
     assert isinstance(rho_allcomps_elbow, float)
     assert isinstance(rho_unclassified_elbow, type(None))
@@ -487,7 +487,7 @@ def test_rho_elbow_kundu_liberal_smoke():
 
     with pytest.raises(ValueError):
         selection_utils.rho_elbow_kundu_liberal(
-            component_table, echo_dof=3, rho_elbow_type="perfect"
+            component_table, n_independent_echos=3, rho_elbow_type="perfect"
         )
 
 

--- a/tedana/tests/test_utils.py
+++ b/tedana/tests/test_utils.py
@@ -102,7 +102,7 @@ def test_make_adaptive_mask(caplog):
     # Decay: good good good (3)
     data[idx + 5, :, :] = np.array([1, 0.9, -1])[:, None]
 
-    # Simulating 5 echo data to test the echo_dof parameter
+    # Simulating 5 echo data to test the n_independent_echos parameter
     data5 = np.concatenate(
         (
             data,
@@ -219,11 +219,11 @@ def test_make_adaptive_mask(caplog):
     assert np.allclose(counts, np.array([3365, 1412, 1195, 58378]))
     assert "No methods provided for adaptive mask generation." in caplog.text
 
-    # testing echo_dof
+    # testing n_independent_echos
     # This should match "decay" from above, except all voxels with 3 good echoes should now have 5
     # since two echoes were added that should not have caused more decay
     mask, adaptive_mask = utils.make_adaptive_mask(
-        data5, mask=mask_file, threshold=1, methods=["decay"], echo_dof=3
+        data5, mask=mask_file, threshold=1, methods=["decay"], n_independent_echos=3
     )
 
     assert mask.shape == adaptive_mask.shape == (64350,)
@@ -246,7 +246,7 @@ def test_make_adaptive_mask(caplog):
     ) in caplog.text
 
     mask, adaptive_mask = utils.make_adaptive_mask(
-        data5, mask=mask_file, threshold=1, methods=["decay"], echo_dof=4
+        data5, mask=mask_file, threshold=1, methods=["decay"], n_independent_echos=4
     )
 
     assert (

--- a/tedana/tests/test_utils.py
+++ b/tedana/tests/test_utils.py
@@ -242,7 +242,7 @@ def test_make_adaptive_mask(caplog):
     assert (
         "10339 voxels (17.0%) have fewer than 3.0 good voxels. "
         "These voxels will be used in all analyses, "
-        "but might not include 3 independant echo measurements."
+        "but might not include 3 independent echo measurements."
     ) in caplog.text
 
     mask, adaptive_mask = utils.make_adaptive_mask(
@@ -252,7 +252,7 @@ def test_make_adaptive_mask(caplog):
     assert (
         "10339 voxels (17.0%) have fewer than 3.0 good voxels. "
         "The degrees of freedom for fits across echoes will remain 4 even if "
-        "there might be fewer independant echo measurements."
+        "there might be fewer independent echo measurements."
     ) in caplog.text
 
 

--- a/tedana/utils.py
+++ b/tedana/utils.py
@@ -237,7 +237,7 @@ def make_adaptive_mask(data, mask, echo_dof=None, threshold=1, methods=["dropout
         # For EPTI sequences, the way we use adaptive mask thresholding fails
         # because sequential echoes have overlapping information.
         # Since EPTI has less dropout, it is unclear how often this will cause issues.
-        # To track this, we are flagging voxels that might mark less independant signal.
+        # To track this, we are flagging voxels that might mark less independent signal.
         # If such voxels appear often, this would show we might need to alter how the mask is used.
         # The thresh where there might not be 3 independent sources of data within the good echoes
         # For n_echos=100 & echo_dof=3, threshold_dof=66.
@@ -250,7 +250,7 @@ def make_adaptive_mask(data, mask, echo_dof=None, threshold=1, methods=["dropout
                 f"{n_3dof_voxels} voxels ({np.round(perc_3dof_voxels, decimals=1)}%) have fewer "
                 f"than {np.round(threshold_3dof)} "
                 "good voxels. These voxels will be used in all analyses, "
-                "but might not include 3 independant echo measurements."
+                "but might not include 3 independent echo measurements."
             )
         # There's a separate warning about DOF if it's possible there's a DOF reduction.
         if echo_dof > 3:
@@ -265,7 +265,7 @@ def make_adaptive_mask(data, mask, echo_dof=None, threshold=1, methods=["dropout
                 f"{n_dof_voxels} voxels ({np.round(perc_dof_voxels, decimals=1)}%) have fewer "
                 f"than {np.round(threshold_dof)} good voxels. "
                 f"The degrees of freedom for fits across echoes will remain {echo_dof} even if "
-                "there might be fewer independant echo measurements."
+                "there might be fewer independent echo measurements."
             )
     modified_mask = adaptive_mask.astype(bool)
     adaptive_mask = unmask(adaptive_mask, mask)

--- a/tedana/workflows/t2smap.py
+++ b/tedana/workflows/t2smap.py
@@ -134,7 +134,7 @@ def _get_parser():
     )
     optional.add_argument(
         "--n-independent-echos",
-        dest="echo_dof",
+        dest="n_independent_echos",
         metavar="INT",
         type=int,
         help=(
@@ -186,7 +186,7 @@ def _get_parser():
 def t2smap_workflow(
     data,
     tes,
-    echo_dof=None,
+    n_independent_echos=None,
     out_dir=".",
     mask=None,
     prefix="",
@@ -213,8 +213,8 @@ def t2smap_workflow(
         list of echo-specific files, in ascending order.
     tes : :obj:`list`
         List of echo times associated with data in milliseconds.
-    echo_dof : :obj:`int`, optional
-        Degree of freedom to use in goodness of fit metrics (fstat).
+    n_independent_echos : :obj:`int`, optional
+        Number of independent echoes to use in goodness of fit metrics (fstat).
         Primarily used for EPTI acquisitions.
         If None, number of echoes will be used. Default is None.
     out_dir : :obj:`str`, optional
@@ -339,7 +339,7 @@ def t2smap_workflow(
     mask, masksum = utils.make_adaptive_mask(
         data_cat,
         mask=mask,
-        echo_dof=echo_dof,
+        n_independent_echos=n_independent_echos,
         threshold=1,
         methods=masktype,
     )

--- a/tedana/workflows/tedana.py
+++ b/tedana/workflows/tedana.py
@@ -372,11 +372,11 @@ def _get_parser():
 
     optional.add_argument(
         "--n-independent-echos",
-        dest="echo_dof",
+        dest="n_independent_echos",
         metavar="INT",
         type=int,
         help=(
-            "Degree of freedom to use in goodness of fit metrics (fstat)."
+            "Number of independent echoes to use in goodness of fit metrics (fstat)."
             "Primarily used for EPTI acquisitions."
             "If not provided, number of echoes will be used."
         ),
@@ -398,7 +398,7 @@ def tedana_workflow(
     masktype=["dropout"],
     fittype="loglin",
     combmode="t2s",
-    echo_dof=None,
+    n_independent_echos=None,
     tree="tedana_orig",
     external_regressors=None,
     ica_method=DEFAULT_ICA_METHOD,
@@ -456,8 +456,8 @@ def tedana_workflow(
         Default is 'loglin'.
     combmode : {'t2s'}, optional
         Combination scheme for TEs: 't2s' (Posse 1999, default).
-    echo_dof : :obj:`int`, optional
-        Degree of freedom to use in goodness of fit metrics (fstat).
+    n_independent_echos : :obj:`int`, optional
+        Number of independent echoes to use in goodness of fit metrics (fstat).
         Primarily used for EPTI acquisitions.
         If None, number of echoes will be used. Default is None.
     tree : {'tedana_orig', 'meica', 'minimal', 'json file'}, optional
@@ -714,7 +714,7 @@ def tedana_workflow(
     mask_denoise, masksum_denoise = utils.make_adaptive_mask(
         data_cat,
         mask=mask,
-        echo_dof=echo_dof,
+        n_independent_echos=n_independent_echos,
         threshold=1,
         methods=masktype,
     )
@@ -794,7 +794,7 @@ def tedana_workflow(
             masksum_clf,
             io_generator,
             tes=tes,
-            echo_dof=echo_dof,
+            n_independent_echos=n_independent_echos,
             algorithm=tedpca,
             kdaw=10.0,
             rdaw=1.0,
@@ -835,7 +835,7 @@ def tedana_workflow(
                 mixing=mixing,
                 adaptive_mask=masksum_clf,
                 tes=tes,
-                echo_dof=echo_dof,
+                n_independent_echos=n_independent_echos,
                 io_generator=io_generator,
                 label="ICA",
                 metrics=necessary_metrics,
@@ -848,7 +848,7 @@ def tedana_workflow(
                 selector,
                 n_echos=n_echos,
                 n_vols=n_vols,
-                echo_dof=echo_dof,
+                n_independent_echos=n_independent_echos,
             )
             n_likely_bold_comps = selector.n_likely_bold_comps_
             LGR.info("Selecting components from ICA results")
@@ -857,7 +857,7 @@ def tedana_workflow(
                 selector,
                 n_echos=n_echos,
                 n_vols=n_vols,
-                echo_dof=echo_dof,
+                n_independent_echos=n_independent_echos,
             )
             n_likely_bold_comps = selector.n_likely_bold_comps_
             if (n_restarts < maxrestart) and (n_likely_bold_comps == 0):
@@ -899,7 +899,7 @@ def tedana_workflow(
             mixing=mixing,
             adaptive_mask=masksum_clf,
             tes=tes,
-            echo_dof=echo_dof,
+            n_independent_echos=n_independent_echos,
             io_generator=io_generator,
             label="ICA",
             metrics=necessary_metrics,
@@ -907,7 +907,11 @@ def tedana_workflow(
             external_regressor_config=selector.tree["external_regressor_config"],
         )
         selector = selection.automatic_selection(
-            component_table, selector, n_echos=n_echos, n_vols=n_vols, echo_dof=echo_dof
+            component_table,
+            selector,
+            n_echos=n_echos,
+            n_vols=n_vols,
+            n_independent_echos=n_independent_echos,
         )
 
     # TODO The ICA mixing matrix should be written out after it is created


### PR DESCRIPTION
Changes proposed in this pull request:

- As discussed in the main PR, I replaced `echo_dof` and references to it with `n_independent_echos`
- One added change of note is `calculate_f_maps`  would not use the adaptive mask when calculating f stats if `n_independent_echos` was defined. Since we're converting `n_independent_echos` from `None` to a number in several places I decided to fix this at the source and to use `j_echo` if `n_independent_echos >= j_echo`. This will change the results if `n_independent_echos` from EPTI is 5 and there are voxels in the adaptive mask with only 3 good echoes, but this is already an edge cause that would send out a warning through `make_adaptive_mask` The change is here & again a few lines lower:
  - [if n_independent_echos is None or n_independent_echos >= j_echo:](https://github.com/handwerkerd/tedana/blob/0ab073a5dbff9ec5e8eae43f0f94705a8c43994f/tedana/metrics/dependence.py#L223)
- In trying to make a nice & more specific new test, I officially overengineered `test_smoke_calculate_f_maps`. Because the inputs are random, it seems to fail with randomly bad inputs. I made changes to make sure there are always a substantive number of voxels in the adaptive mask with 1-5 good echoes and I tweaked the assertions to reduce the chances of more edge cases causing failures.
- While I was making changes, I corrected a few more times "independant" was misspelled in the code

@tsalo You can review after @katielamar has a chance to merge into her PR, but I wanted to make sure you saw my comments about what I changed.